### PR TITLE
docs: add getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# paris-vite-plugin
+
+A lightweight wrapper around the `@module-federation/vite` plugin that powers Module Federation in Vite apps. It exports the federation plugin as `paris` and provides a `createParis` helper to bootstrap the runtime at startup.
+
+### Remote app example
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import paris from 'paris-vite-plugin';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    paris({
+      name: 'remote',
+      exposes: {
+        './Button': resolve(__dirname, './src/Button.ts'),
+      },
+      shared: ['vue'],
+    }),
+  ],
+});
+```
+
+### Host app example
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import paris from 'paris-vite-plugin';
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    paris({
+      name: 'shell',
+      remotes: {
+        foo: 'http://localhost:5174/assets/remoteEntry.js',
+      },
+      shared: ['vue'],
+    }),
+  ],
+});
+```
+
+### Runtime setup with `createParis`
+
+```ts
+// main.ts
+import { createParis } from 'paris-vite-plugin';
+
+createParis({
+  name: 'shell',
+  remotes: {
+    foo: 'http://localhost:5174/assets/remoteEntry.js',
+  },
+});
+```
+
+---
+
+## Installation
+
+1. Requires Node v18 or higher. Install the plugin with **npm**:
+
+```shell
+npm i -D paris-vite-plugin
+```
+
+2. Add `paris` to the `plugins` array in your `vite.config.ts`.
+
+3. Configure `remotes` or `exposes` and run Vite:
+
+```shell
+vite
+```
+
+**You're all set!**
+
+---
+
+## Tips & Tricks
+
+1. Use the `shared` option to avoid shipping duplicate dependencies across remotes.
+2. Call `createParis` in the host to customize the Module Federation runtime or preload remotes.
+3. Combine with Vite's `build.ssr` option to federate server and client builds.
+
+---
+
+**paris-vite-plugin**  
+by Kenny Romanov

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # paris-vite-plugin
 
-A lightweight wrapper around the `@module-federation/vite` plugin that powers Module Federation in Vite apps. It exports the federation plugin as `paris` and provides a `createParis` helper to bootstrap the runtime at startup.
+A lightweight wrapper for the `@module-federation/vite` that powers [Paris](https://www.npmjs.com/package/@kennyromanov/paris) — a Module Federating Tool for Vite apps. It exports the federation plugin and provides a `createParis` helper to bootstrap the runtime.
 
-### Remote app example
+### Here's a simplae example:
 
 ```ts
 // vite.config.ts
@@ -19,13 +19,12 @@ export default defineConfig({
       exposes: {
         './Button': resolve(__dirname, './src/Button.ts'),
       },
-      shared: ['vue'],
     }),
   ],
 });
 ```
 
-### Host app example
+### Shell host example
 
 ```ts
 // vite.config.ts
@@ -39,15 +38,14 @@ export default defineConfig({
     paris({
       name: 'shell',
       remotes: {
-        foo: 'http://localhost:5174/assets/remoteEntry.js',
+        foo: 'http://localhost:5174/assets/paris.js',
       },
-      shared: ['vue'],
     }),
   ],
 });
 ```
 
-### Runtime setup with `createParis`
+### Runtime example:
 
 ```ts
 // main.ts
@@ -56,7 +54,7 @@ import { createParis } from 'paris-vite-plugin';
 createParis({
   name: 'shell',
   remotes: {
-    foo: 'http://localhost:5174/assets/remoteEntry.js',
+    foo: 'http://localhost:5174/assets/paris.js',
   },
 });
 ```
@@ -71,7 +69,7 @@ createParis({
 npm i -D paris-vite-plugin
 ```
 
-2. Add `paris` to the `plugins` array in your `vite.config.ts`.
+2. Add `paris` to the `plugins` section in your `vite.config.ts`.
 
 3. Configure `remotes` or `exposes` and run Vite:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ export default defineConfig({
 });
 ```
 
-### Shell host example
+### Shell host example:
 
 ```ts
 // vite.config.ts


### PR DESCRIPTION
## Summary
- rewrite README to focus on paris-vite-plugin with remote and host examples
- add tips about shared dependencies and runtime initialization with createParis

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f101c8f988332bfb6d19f18d81257